### PR TITLE
release(heliotrope): bump up 5.3.0 to 5.3.5

### DIFF
--- a/heliotrope/__init__.py
+++ b/heliotrope/__init__.py
@@ -9,7 +9,7 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info = VersionInfo(major=5, minor=3, micro=0, releaselevel="final", serial=0)
+version_info = VersionInfo(major=5, minor=3, micro=5, releaselevel="final", serial=0)
 
 __version__ = f"{version_info.major}.{version_info.minor}.{version_info.micro}"
 __detailed_version__ = f"{__version__}-{version_info.releaselevel}"


### PR DESCRIPTION
fix(common): execute after finding directly without parsing (#72) 

chore(deps): bump sentry-sdk from 1.4.3 to 1.5.0 (#68)

chore(deps): bump aiomysql from 0.0.21 to 0.0.22 (#66) 

chore(deps): bump aiohttp from 3.8.0 to 3.8.1 (#65)

chore(deps): bump lxml from 4.6.3 to 4.6.4 (#61 

4 deps updated

1 bug fixes