### PR TITLE
feat: large number handling with BigInteger

### DIFF
--- a/heliotrope/database/orm/table/gallleryinfo.py
+++ b/heliotrope/database/orm/table/gallleryinfo.py
@@ -22,14 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 from sqlalchemy.sql.schema import Column, Table
-from sqlalchemy.sql.sqltypes import Integer, String
+from sqlalchemy.sql.sqltypes import BigInteger, String
 
 from heliotrope.database.orm.base import mapper_registry
 
 galleryinfo_table = Table(
     "galleryinfo",
     mapper_registry.metadata,
-    Column("id", Integer, primary_key=True, nullable=False),
+    Column("id", BigInteger, primary_key=True, nullable=False),
     Column("type", String, nullable=False),
     # title
     Column("title", String, nullable=False),


### PR DESCRIPTION
Fix #230      

int4 (32-bit) has limit of 
2147483647, causing error on input
1000000000000000.

BigInteger is int8 (64-bit) with a limit of
9223372036854775807, enough for the input at hand.

Overflow of BigInteger will need new solutions.
Thank you.

Signed-off-by: Wonhyeong Seo <29195190+wonhyeongseo@users.noreply.github.com>

### Check Box

- [x] Changes to this PR can be deployed immediately.
