### PR TITLE
release(heliotrope): bump up 6.0.0 to 6.2.7

### DIFF
--- a/heliotrope/__init__.py
+++ b/heliotrope/__init__.py
@@ -32,6 +32,9 @@ class VersionInfo(NamedTuple):
     serial: int
 
 
-version_info = VersionInfo(major=6, minor=0, micro=0, releaselevel="final", serial=0)
+version_info = VersionInfo(major=6, minor=2, micro=7, releaselevel="final", serial=0)
 
-__version__ = f"{version_info.major}.{version_info.minor}.{version_info.micro}-{version_info.releaselevel}.{version_info.serial}"
+__version__ = f"{version_info.major}.{version_info.minor}.{version_info.micro}"
+
+if version_info.releaselevel != "final":
+    __version__ = f"{__version__}-{version_info.releaselevel}.{version_info.serial}"


### PR DESCRIPTION
* feat: support multiple language by @SaidBySolo in https://github.com/Saebasol/Heliotrope/pull/253
* fix(orm): handle int32 @SaidBySolo in https://github.com/Saebasol/Heliotrope/commit/fa5a4b1214a44f29df231b675bc5f69f5a3dc3c0
* perf: remove bs4 dependency by @SaidBySolo in https://github.com/Saebasol/Heliotrope/pull/221
* chore(deps): remove bs4 by @SaidBySolo in https://github.com/Saebasol/Heliotrope/pull/222
* chore(deps): bump motor from 2.5.1 to 3.0.0 by @dependabot in https://github.com/Saebasol/Heliotrope/pull/223
* chore(deps): bump sqlalchemy[asyncio,mypy] from 1.4.38 to 1.4.39 by @dependabot in https://github.com/Saebasol/Heliotrope/pull/236
* chore(deps): bump lxml from 4.9.0 to 4.9.1 by @dependabot in https://github.com/Saebasol/Heliotrope/pull/241
* chore(deps): bump asyncpg from 0.25.0 to 0.26.0 by @dependabot in https://github.com/Saebasol/Heliotrope/pull/243
* chore(deps): bump sentry-sdk from 1.8.0 to 1.9.0 by @dependabot in https://github.com/Saebasol/Heliotrope/pull/251
* chore(deps): bump sanic[ext] from 22.6.0 to 22.6.1 by @dependabot in https://github.com/Saebasol/Heliotrope/pull/254

2 minor (feat, fix)

7 micro (deps, perf)


### Check Box

- [x] Changes to this PR can be deployed immediately.
